### PR TITLE
remove reference to setting Symfony version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ vendor/bin/config-transformer switch-format config/packages/config-transformer.y
 
 The input file will be deleted automatically.
 
-## Configuration
-
-With `--target-symfony-version`/`-s` option you specify, what Symfony features should be used (3.2 is used by default).
-
-```bash
-vendor/bin/config-transformer switch-format app/config -s 3.3
-```
-
 *Note: Symfony YAML parser removes all comments, so be sure to go through files and add still-relevant comments manually.*
 
 <br>


### PR DESCRIPTION
The -s option no longer exists.