### PR TITLE
Add monorepo-builder to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,17 @@
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
-        "phpunit/phpunit": "^9.5.26",
-        "symfony/framework-bundle": "6.1.*",
-        "symplify/easy-testing": "^11.2",
-        "rector/rector": "*",
-        "phpstan/phpstan": "^1.9",
-        "symplify/easy-coding-standard": "11.1.29.72",
-        "symplify/easy-ci": "^11.1",
-        "symplify/phpstan-extensions": "^11.1",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/extension-installer": "^1.2",
-        "php-parallel-lint/php-parallel-lint": "^1.3"
+        "phpstan/phpstan": "^1.9",
+        "phpunit/phpunit": "^9.5.26",
+        "rector/rector": "*",
+        "symfony/framework-bundle": "6.1.*",
+        "symplify/easy-ci": "^11.1",
+        "symplify/easy-coding-standard": "11.1.29.72",
+        "symplify/easy-testing": "^11.2",
+        "symplify/monorepo-builder": "^11.1.24",
+        "symplify/phpstan-extensions": "^11.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
@TomasVotruba this is to make script in composer.json runnable:

https://github.com/symplify/config-transformer/blob/0009a6133f26bde0572c75dcb3690fc03fcbcf98/composer.json#L68