### PR TITLE
Add missing bootstrap on prefixed 72

### DIFF
--- a/bin/config-transformer.php
+++ b/bin/config-transformer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Symplify\ConfigTransformer\Kernel\ConfigTransformerKernel;
 use Symplify\SymplifyKernel\ValueObject\KernelBootAndApplicationRun;
 
+define('__CONFIG_TRANSFORMER_RUNNING__', true);
+
 $possibleAutoloadPaths = [
     // dependency
     __DIR__ . '/../../../autoload.php',

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+// inspired by https://github.com/phpstan/phpstan/blob/master/bootstrap.php
+spl_autoload_register(function (string $class): void {
+    static $composerAutoloader;
+
+    // already loaded in bin/config-transformer.php
+    if (defined('__CONFIG_TRANSFORMER_RUNNING__')) {
+        return;
+    }
+
+    // load prefixed or native class, e.g. for running tests
+    if (strpos($class, 'ConfigTransformerPrefix') === 0 || strpos($class, 'Symplify\\ConfigTransformer\\') === 0) {
+        if ($composerAutoloader === null) {
+            // prefixed version autoload
+            $composerAutoloader = require __DIR__ . '/vendor/autoload.php';
+        }
+
+        // some weird collision with PHPStan custom rule tests
+        if (! is_int($composerAutoloader)) {
+            $composerAutoloader->loadClass($class);
+        }
+    }
+});

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,5 +7,10 @@
     },
     "bin": [
         "bin/config-transformer"
-    ]
+    ],
+    "autoload": {
+        "files": [
+            "bootstrap.php"
+        ]
+    }
 }

--- a/scoper.php
+++ b/scoper.php
@@ -35,7 +35,7 @@ $polyfillsStubs = array_map(
 
 // see https://github.com/humbug/php-scoper
 return [
-    'prefix' => 'ConfigTransformer' . $timestamp,
+    'prefix' => 'ConfigTransformerPrefix' . $timestamp,
     'expose-constants' => ['#^SYMFONY\_[\p{L}_]+$#'],
 
     // excluded


### PR DESCRIPTION
To avoid same issue like in the monorepo-builder one https://github.com/symplify/monorepo-builder/issues/14