### PR TITLE
Fix: Allow running command with `switch-format` argument

### DIFF
--- a/src/Console/ConfigTransformerApplication.php
+++ b/src/Console/ConfigTransformerApplication.php
@@ -17,7 +17,6 @@ final class ConfigTransformerApplication extends Application
 
         $this->add($switchFormatCommand);
 
-        // make single command application
-        $this->setDefaultCommand('switch-format', true);
+        $this->setDefaultCommand('switch-format');
     }
 }


### PR DESCRIPTION
This pull request

- [x] allows running the command with `switch-format` argument

Follows https://github.com/symplify/config-transformer/issues/11#issuecomment-1410081176.

💁‍♂️ For reference, see

- https://github.com/symfony/console/blob/v6.2.0/Application.php#L1182-L1194
- https://github.com/symfony/console/blob/v6.2.0/Application.php#L1065-L1068