### PR TITLE
Fix: Do not use hard-coded command name

### DIFF
--- a/src/Console/ConfigTransformerApplication.php
+++ b/src/Console/ConfigTransformerApplication.php
@@ -18,6 +18,6 @@ final class ConfigTransformerApplication extends Application
         $this->add($switchFormatCommand);
 
         // make single command application
-        $this->setDefaultCommand('switch-format', true);
+        $this->setDefaultCommand($switchFormatCommand->getName(), true);
     }
 }


### PR DESCRIPTION
This pull request

- [x] stops using a hard-coded command name in `ConfigTransformerApplication`