### PR TITLE
Fix: Remove command name from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ vendor/bin/config-transformer
 Do you want to convert 1 files or directory at a time? Specify the paths as arguments:
 
 ```bash
-vendor/bin/config-transformer transform config/parameters.yml
+vendor/bin/config-transformer config/parameters.yml
 ```
 
 The input files are deleted automatically.


### PR DESCRIPTION
This pull request

- [x] removes the command name from the example in `README.md`