### PR TITLE
Fix quoting of unquoted parameters #24

### DIFF
--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -37,7 +37,7 @@ final class ConfigLoader
      * @see https://regex101.com/r/spi4ir/1
      * @var string
      */
-    private const UNQUOTED_PARAMETER_REGEX = '#(\w+:\s+)(\%(.*?)%)(.*?)?$#m';
+    private const UNQUOTED_PARAMETER_REGEX = '#^(\s*\w+:\s+)(\%(.*?)%)(.*?)?$#m';
 
     public function __construct(
         private IdAwareXmlFileLoaderFactory $idAwareXmlFileLoaderFactory,

--- a/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/unquoted_param.yaml
+++ b/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/unquoted_param.yaml
@@ -1,6 +1,7 @@
 parameters:
     key: %value%
     nested: %kernel.cache_dir%/some_path
+    already_quoted: 'Message: %%message%%'
 -----
 <?php
 
@@ -14,4 +15,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('key', '%value%');
 
     $parameters->set('nested', '%kernel.cache_dir%/some_path');
+
+    $parameters->set('already_quoted', 'Message: %%message%%');
 };


### PR DESCRIPTION
Make the regex only replace strings where the parameters aren't inside in an already quoted string, by starting from the start of the line and then only acting on the first `:` found.