### PR TITLE
Allow single file on ConfigFileFinder

### DIFF
--- a/src/Finder/ConfigFileFinder.php
+++ b/src/Finder/ConfigFileFinder.php
@@ -21,6 +21,16 @@ final class ConfigFileFinder
      */
     public function findFileInfos(array $sources): array
     {
+        if (count($sources) === 1 && is_file($sources[0])) {
+            $path = realpath($sources[0]);
+            return [
+                new SplFileInfo(
+                    $path,
+                    $sources[0],
+                    $sources[0]
+                )];
+        }
+
         $finder = new Finder();
         $finder->files()
             ->in($sources)


### PR DESCRIPTION
**Before**

```
➜  config-transformer git:(main) ✗ bin/config-transformer convert foo.yaml                   

In Finder.php line 649:
                                            
  The "foo.yaml" directory does not exist.  
```

**After**

```
➜  config-transformer git:(allow-single-file) ✗ bin/config-transformer convert foo.yaml

File "foo.yaml" was renamed to "foo.php"
========================================


Closes https://github.com/symplify/config-transformer/issues/30

                                                                                                                        
 [OK] Processed 1 file(s) to "PHP" format, congrats!                                                                    
                                                                                                                        
```