### PR TITLE
correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ vendor/bin/config-transformer
 Do you want to convert 1 files or directory at a time? Specify the paths as arguments:
 
 ```bash
-vendor/bin/config-transformer config/parameters.yml
+vendor/bin/config-transformer convert config/parameters.yml
 ```
 
 The input files are deleted automatically.


### PR DESCRIPTION
When trying to convert one yaml to php, I copied the command from the readme, and it did not work, it seems it was missing the `convert` command before the argument 

![ScreenShot-2023-12-29-23 21 09](https://github.com/symplify/config-transformer/assets/400092/16591442-c1d0-43e9-a5dc-df2517115364)
