### PR TITLE
 Bump php-config-printer to automatically detect ref/service function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/filesystem": "^6.4",
         "symfony/finder": "^6.4",
         "symfony/yaml": "^6.4",
-        "symplify/php-config-printer": "^12.0.1",
+        "symplify/php-config-printer": "^12.0.2",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {


### PR DESCRIPTION
Closes https://github.com/symplify/config-transformer/issues/46