### PR TITLE
Remove XML support from composer project description.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symplify/config-transformer",
-    "description": "Convert Symfony YAML/XML format to PHP/YAML",
+    "description": "Convert Symfony YAML configs to PHP",
     "license": "MIT",
     "bin": [
         "bin/config-transformer"


### PR DESCRIPTION
Update project description in `composer.json` to remove XML support, and support of converting into YAML, as XML support is to complex

see: https://github.com/symplify/config-transformer/commit/11a8716dec80c0e9d9f45f46021c7efeeb4e1ea8