### PR TITLE
fix: ignore `xml` prefixed files from files finder

### DIFF
--- a/src/Finder/ConfigFileFinder.php
+++ b/src/Finder/ConfigFileFinder.php
@@ -13,7 +13,7 @@ final class ConfigFileFinder
      * @see https://regex101.com/r/jmxqCg/1
      * @var string
      */
-    private const CONFIG_SUFFIXES_REGEX = '#\.(yml|yaml|xml)$#';
+    private const CONFIG_SUFFIXES_REGEX = '#\.(yml|yaml)$#';
 
     /**
      * @param string[] $sources


### PR DESCRIPTION
XML support has been removed, because to complex, xml files must be ignored from file finder to avoid having `NotImplementedYetException`

see: [11a8716](https://github.com/symplify/config-transformer/commit/11a8716dec80c0e9d9f45f46021c7efeeb4e1ea8)


Error when runing config-transformer with xml files in configs :
```bash
php ./bin/config-transformer --dry-run

In ConfigLoader.php line 83:
       
  xml  
       

switch-format [-n|--dry-run] [--skip-routes] [--] [<sources>...]
```
