### PR TITLE
fix: Support `%kernel.project_dir%` in services `resource` (fixes symplify/config-transformer#57)

### DIFF
--- a/src/Converter/YamlToPhpConverter.php
+++ b/src/Converter/YamlToPhpConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\ConfigTransformer\Converter;
 
+use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
@@ -53,7 +54,7 @@ final class YamlToPhpConverter
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new StripDirInPathStartingWithParameterNodeVisitor());
 
-        /** @var \PhpParser\Node\Stmt[] $stmts */
+        /** @var Stmt[] $stmts */
         $stmts = $nodeTraverser->traverse([$return]);
 
         return $this->phpParserPhpConfigPrinter->prettyPrintFile($stmts);

--- a/src/Converter/YamlToPhpConverter.php
+++ b/src/Converter/YamlToPhpConverter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Symplify\ConfigTransformer\Converter;
 
+use PhpParser\NodeTraverser;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
+use Symplify\ConfigTransformer\NodeVisitor\StripDirInPathStartingWithParameterNodeVisitor;
 use Symplify\ConfigTransformer\Routing\RoutingConfigDetector;
 use Symplify\PhpConfigPrinter\NodeFactory\ContainerConfiguratorReturnClosureFactory;
 use Symplify\PhpConfigPrinter\NodeFactory\RoutingConfiguratorReturnClosureFactory;
@@ -48,6 +50,12 @@ final class YamlToPhpConverter
             $return = $this->containerConfiguratorReturnClosureFactory->createFromYamlArray($yamlArray);
         }
 
-        return $this->phpParserPhpConfigPrinter->prettyPrintFile([$return]);
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor(new StripDirInPathStartingWithParameterNodeVisitor());
+
+        /** @var \PhpParser\Node\Stmt[] $stmts */
+        $stmts = $nodeTraverser->traverse([$return]);
+
+        return $this->phpParserPhpConfigPrinter->prettyPrintFile($stmts);
     }
 }

--- a/src/NodeVisitor/StripDirInPathStartingWithParameterNodeVisitor.php
+++ b/src/NodeVisitor/StripDirInPathStartingWithParameterNodeVisitor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\ConfigTransformer\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Turns `__DIR__ . '/%kernel.project_dir%/src/Article'` into
+ * `'%kernel.project_dir%/src/Article'`, so Symfony parameters in paths
+ * stay intact instead of being prefixed with the current directory.
+ */
+final class StripDirInPathStartingWithParameterNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof Concat) {
+            return null;
+        }
+
+        if (! $node->left instanceof Dir) {
+            return null;
+        }
+
+        if (! $node->right instanceof String_) {
+            return null;
+        }
+
+        $value = $node->right->value;
+        if (! \str_starts_with($value, '/%')) {
+            return null;
+        }
+
+        return new String_(\ltrim($value, '/'));
+    }
+}

--- a/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_load_resource_kernel_project_dir.yaml
+++ b/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_load_resource_kernel_project_dir.yaml
@@ -1,0 +1,23 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
+  App\Article\:
+    resource: "%kernel.project_dir%/src/Article"
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('App\Article\\', '%kernel.project_dir%/src/Article');
+};


### PR DESCRIPTION
## Summary
Fixes symplify/config-transformer#57 — Support `%kernel.project_dir%` in services `resource`

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.